### PR TITLE
Add helpComponent, update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,172 @@
-/bin
-/.classpath
-/.project
-/.settings
-/target
+# Created by https://www.gitignore.io/api/osx,java,eclipse,intellij,maven
+# Edit at https://www.gitignore.io/?templates=osx,java,eclipse,intellij,maven
+ 
+### Eclipse ###
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+ 
+# External tool builders
+.externalToolBuilders/
+ 
+# Locally stored "Eclipse launch configurations"
+*.launch
+ 
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+ 
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+ 
+# CDT- autotools
+.autotools
+ 
+# Java annotation processor (APT)
+.factorypath
+ 
+# PDT-specific (PHP Development Tools)
+.buildpath
+ 
+# sbteclipse plugin
+.target
+ 
+# Tern plugin
+.tern-project
+ 
+# TeXlipse plugin
+.texlipse
+ 
+# STS (Spring Tool Suite)
+.springBeans
+ 
+# Code Recommenders
+.recommenders/
+ 
+# Annotation Processing
+.apt_generated/
+ 
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+ 
+### Eclipse Patch ###
+# Eclipse Core
+.project
+ 
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+ 
+# Annotation Processing
+.apt_generated
+ 
+.sts4-cache/
+ 
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+*.iml
+*.ipr
+ 
+# CMake
+cmake-build-*/
+ 
+# File-based project format
+*.iws
+ 
+# IntelliJ
+out/
+ 
+# JIRA plugin
+atlassian-ide-plugin.xml
+ 
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+ 
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+ 
+# modules.xml
+*.ipr
+.idea/
+ 
+### Java ###
+# Compiled class file
+*.class
+ 
+# Log file
+*.log
+ 
+# BlueJ files
+*.ctxt
+ 
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+ 
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+ 
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+ 
+### Maven ###
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+ 
+### OSX ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+ 
+# Icon must end with two \r
+Icon
+ 
+# Thumbnails
+._*
+ 
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+ 
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+ 
+build.xml
+.build.xml
+# End of https://www.gitignore.io/api/osx,java,eclipse,intellij,maven

--- a/src/main/java/de/craftlancer/core/command/CommandHandler.java
+++ b/src/main/java/de/craftlancer/core/command/CommandHandler.java
@@ -1,25 +1,41 @@
 package de.craftlancer.core.command;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
+import de.craftlancer.core.LambdaRunnable;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.HoverEvent;
 import org.apache.commons.lang.Validate;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.plugin.Plugin;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 // TODO implement usage of HelpMap and HelpTopic via HelpMapFactory
 // TODO externalize common code between CommandHandler and SubCommandHandler
 public abstract class CommandHandler implements TabExecutor {
+    
+    private HelpLabelManager manager;
     private Map<String, SubCommand> commands = new HashMap<>();
     private Plugin plugin;
     
     public CommandHandler(Plugin plugin) {
         this.plugin = plugin;
+    }
+    
+    public CommandHandler(Plugin plugin, String label) {
+        this.plugin = plugin;
+        this.manager = new HelpLabelManager(label.toLowerCase());
+        
+        new LambdaRunnable(this::registerSubCommands).runTaskLater(plugin, 4);
     }
     
     @Override
@@ -31,10 +47,12 @@ public abstract class CommandHandler implements TabExecutor {
         if (args.length == 0 || !commands.containsKey(args[0])) {
             if (commands.containsKey("help"))
                 message = commands.get("help").execute(sender, cmd, label, args);
-            else
+            else if (manager != null) {
+                sender.spigot().sendMessage(manager.getHelpComponent(sender, this));
+                return true;
+            } else
                 return false;
-        }
-        else
+        } else
             message = commands.get(args[0]).execute(sender, cmd, label, args);
         
         if (message != null)
@@ -50,7 +68,7 @@ public abstract class CommandHandler implements TabExecutor {
                 return Collections.emptyList();
             case 1:
                 return commands.keySet().stream().filter(a -> a.startsWith(args[0])).filter(a -> commands.get(a).getPermission().isEmpty() || sender.hasPermission(commands.get(a).getPermission()))
-                               .collect(Collectors.toList());
+                        .collect(Collectors.toList());
             default:
                 if (!commands.containsKey(args[0]))
                     return Collections.emptyList();
@@ -59,6 +77,8 @@ public abstract class CommandHandler implements TabExecutor {
         }
     }
     
+    public abstract void registerSubCommands();
+    
     public void registerSubCommand(String name, SubCommand command, String... alias) {
         Validate.notNull(command, "Command can't be null!");
         Validate.notEmpty(name, "Commandname can't be empty!");
@@ -66,9 +86,12 @@ public abstract class CommandHandler implements TabExecutor {
         for (String a : alias)
             Validate.isTrue(!commands.containsKey(a), "Command " + a + " is already defined");
         
-        if (command instanceof SubCommandHandler)
+        if (command instanceof SubCommandHandler) {
             Validate.isTrue(((SubCommandHandler) command).getDepth() == 1, "The depth of a SubCommandHandler must be the depth of the previous Handler + 1!");
-        
+            ((SubCommandHandler) command).addHelpLabelManager(manager);
+        } else {
+            command.addHelpLabel(manager, name);
+        }
         commands.put(name, command);
         for (String s : alias)
             commands.put(s, command);
@@ -80,5 +103,124 @@ public abstract class CommandHandler implements TabExecutor {
     
     protected Map<String, SubCommand> getCommands() {
         return commands;
+    }
+    
+    public String getPluginColor() {
+        return ChatColor.DARK_PURPLE + "" + ChatColor.BOLD;
+    }
+    
+    public String getRequiredArgumentColors() {
+        return ChatColor.DARK_PURPLE + "";
+    }
+    
+    public String getOptionalArgumentsColor() {
+        return ChatColor.DARK_GREEN + "";
+    }
+    
+    public String getCommandLabelColor() {
+        return ChatColor.GOLD + "";
+    }
+    
+    public class HelpLabelManager {
+        private final String MESSAGE_LINE = ChatColor.DARK_GRAY + "+-------------------------------------------+";
+        private final String NEW_LINE = "\n";
+        
+        private List<HelpLabel> helpLabels = new ArrayList<>();
+        private String label;
+        
+        public HelpLabelManager(String originLabel) {
+            this.label = originLabel;
+        }
+        
+        public void addLabel(String label) {
+            this.label += label;
+        }
+        
+        public String getLabel() {
+            return label;
+        }
+        
+        public void addHelpLabel(HelpLabel helpLabel) {
+            helpLabels.add(helpLabel);
+        }
+        
+        private BaseComponent[] getHelpComponent(CommandSender sender, CommandHandler handler) {
+            ComponentBuilder componentBuilder = new ComponentBuilder();
+            
+            componentBuilder.append(MESSAGE_LINE);
+            componentBuilder.append(NEW_LINE);
+            componentBuilder.append(getPluginColor() + "  " + plugin.getDescription().getName() + ChatColor.GRAY + " " + plugin.getDescription().getVersion());
+            componentBuilder.append(NEW_LINE);
+            componentBuilder.append(NEW_LINE);
+            componentBuilder.append(ChatColor.GRAY + "  * " + getRequiredArgumentColors() + "[] " + ChatColor.GRAY + "- required arguments");
+            componentBuilder.append(NEW_LINE);
+            componentBuilder.append(ChatColor.GRAY + "  * " + getOptionalArgumentsColor() + "<> " + ChatColor.GRAY + "- optional arguments");
+            componentBuilder.append(NEW_LINE);
+            componentBuilder.append(NEW_LINE);
+            helpLabels.stream().filter(label -> label == null || label.getPermission().equals("") || sender.hasPermission(label.getPermission()))
+                    .forEach(label -> componentBuilder.append(label.getComponents(handler)));
+            componentBuilder.append(NEW_LINE);
+            componentBuilder.append(MESSAGE_LINE);
+            
+            return componentBuilder.create();
+        }
+    }
+    
+    public static class HelpLabel {
+        private static final String NEW_LINE = "\n";
+        private String label;
+        private String permission;
+        private String description;
+        private String[] args;
+        
+        public HelpLabel(String label, String description, String permission, String[] args) {
+            this.label = label;
+            this.permission = permission;
+            this.description = description;
+            this.args = args;
+        }
+        
+        public BaseComponent[] getComponents(CommandHandler handler) {
+            ComponentBuilder componentBuilder = new ComponentBuilder()
+                    .append(ChatColor.GRAY + "  - " + handler.getCommandLabelColor() + "/" + label)
+                    .event(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                            new ComponentBuilder(ChatColor.YELLOW + "Click to suggest command " + handler.getCommandLabelColor() + "/" + label).create()))
+                    .event(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/" + label + " "));
+            if (args != null)
+                componentBuilder.append(getArgsComponent(handler));
+            componentBuilder.append((description == null ? "" : ChatColor.GRAY + " - " + ChatColor.YELLOW + description))
+                    .append(NEW_LINE);
+            
+            return componentBuilder.create();
+        }
+        
+        private BaseComponent[] getArgsComponent(CommandHandler handler) {
+            ComponentBuilder builder = new ComponentBuilder();
+            for (String string : args) {
+                if ((!string.contains("<") && !string.contains(">")) && (!string.contains("[") && !string.contains("]")))
+                    throw new IllegalArgumentException("Given arguments from label " + label + " do not include required set of '[]' or '<>'. See 'addHelpLabel' method javadocs for more info.");
+                
+                builder.append(" ")
+                        .append(string.contains("<") ? handler.getOptionalArgumentsColor() + string : handler.getRequiredArgumentColors() + string);
+            }
+            
+            return builder.create();
+        }
+        
+        public String getLabel() {
+            return label;
+        }
+        
+        public String getDescription() {
+            return description;
+        }
+        
+        public String[] getArgs() {
+            return args;
+        }
+        
+        public String getPermission() {
+            return permission;
+        }
     }
 }

--- a/src/main/java/de/craftlancer/core/command/SubCommand.java
+++ b/src/main/java/de/craftlancer/core/command/SubCommand.java
@@ -1,17 +1,20 @@
 package de.craftlancer.core.command;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+
 public abstract class SubCommand {
     private String permission = "";
     protected Plugin plugin;
     private boolean console;
+    private String description;
+    private String[] args;
     
     public SubCommand(String permission, Plugin plugin, boolean console) {
         this.permission = permission;
@@ -38,23 +41,43 @@ public abstract class SubCommand {
         return permission;
     }
     
+    public void setDescription(@Nullable String description) {
+        this.description = description;
+    }
+    
+    public void addHelpLabel(CommandHandler.HelpLabelManager manager, String subCommandLabel) {
+        CommandHandler.HelpLabel helpLabel = new CommandHandler.HelpLabel(manager.getLabel() + " " + subCommandLabel, description, permission, args);
+        manager.addHelpLabel(helpLabel);
+    }
+    
+    /**
+     * Used to show required/optional arguments in the help component.
+     *
+     * @param arguments Each argument in the command, in the order used.
+     *                  Use brackets [] around an argument to specify a required argument
+     *                  Use arrows <> around an argument to specify an optional argument
+     */
+    public void setArguments(String... arguments) {
+        this.args = arguments;
+    }
+    
     /**
      * The code that will be executed when the sub command is called
-     * 
+     *
      * @param sender the sender of the command
-     * @param cmd the root command
-     * @param label the command's label
-     * @param args the arguments provided to the command, they are already processed to support input with space chars
+     * @param cmd    the root command
+     * @param label  the command's label
+     * @param args   the arguments provided to the command, they are already processed to support input with space chars
      * @return a String, that will be send to the player, used for error messages. No message will be shown, when this
-     *         is null
+     * is null
      */
     protected abstract String execute(CommandSender sender, Command cmd, String label, String[] args);
     
     /**
      * Requests a list of possible completions for a command argument
-     * 
+     *
      * @param sender Source of the command
-     * @param args The arguments passed to the command, including final partial argument to be completed and command label
+     * @param args   The arguments passed to the command, including final partial argument to be completed and command label
      * @return a list of possible completions for the command argument
      */
     protected List<String> onTabComplete(CommandSender sender, String[] args) {

--- a/src/main/java/de/craftlancer/core/command/SubCommand.java
+++ b/src/main/java/de/craftlancer/core/command/SubCommand.java
@@ -5,7 +5,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -13,8 +12,6 @@ public abstract class SubCommand {
     private String permission = "";
     protected Plugin plugin;
     private boolean console;
-    private String description;
-    private String[] args;
     
     public SubCommand(String permission, Plugin plugin, boolean console) {
         this.permission = permission;
@@ -41,24 +38,20 @@ public abstract class SubCommand {
         return permission;
     }
     
-    public void setDescription(@Nullable String description) {
-        this.description = description;
-    }
-    
-    public void addHelpLabel(CommandHandler.HelpLabelManager manager, String subCommandLabel) {
-        CommandHandler.HelpLabel helpLabel = new CommandHandler.HelpLabel(manager.getLabel() + " " + subCommandLabel, description, permission, args);
-        manager.addHelpLabel(helpLabel);
-    }
-    
     /**
      * Used to show required/optional arguments in the help component.
      *
-     * @param arguments Each argument in the command, in the order used.
-     *                  Use brackets [] around an argument to specify a required argument
-     *                  Use arrows <> around an argument to specify an optional argument
+     * @return An array of strings to be set as the arguments.
      */
-    public void setArguments(String... arguments) {
-        this.args = arguments;
+    public abstract String[] getArgs();
+    
+    /**
+     * @return The description
+     */
+    public abstract String getDescription();
+    
+    public CommandHandler.HelpLabel getHelpLabel() {
+        return new CommandHandler.HelpLabel(getDescription(), permission, getArgs());
     }
     
     /**

--- a/src/main/java/de/craftlancer/core/command/SubCommandHandler.java
+++ b/src/main/java/de/craftlancer/core/command/SubCommandHandler.java
@@ -1,36 +1,37 @@
 package de.craftlancer.core.command;
 
+import de.craftlancer.core.LambdaRunnable;
+import org.apache.commons.lang.Validate;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
+
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.Validate;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-import org.bukkit.plugin.Plugin;
-
-public abstract class SubCommandHandler extends SubCommand
-{
-    private Map<String, SubCommand> commands = new HashMap<String, SubCommand>();
+public abstract class SubCommandHandler extends SubCommand {
+    private Map<String, SubCommand> commands = new HashMap<>();
     private int depth;
+    private List<CommandHandler.HelpLabelManager> helpLabelManagers = new ArrayList<>();
     
-    public SubCommandHandler(String permission, Plugin plugin, boolean console, int depth)
-    {
+    public SubCommandHandler(String permission, Plugin plugin, boolean console, int depth) {
         super(permission, plugin, console);
         Validate.isTrue(depth >= 1, "SubCommandHandler depth can't be smaller than 0!");
         this.depth = depth;
+        
+        new LambdaRunnable(this::registerSubCommands).runTaskLater(plugin, 4);
     }
     
     @Override
-    protected String execute(CommandSender sender, Command cmd, String label, String[] args)
-    {
+    protected String execute(CommandSender sender, Command cmd, String label, String[] args) {
         if (args.length <= getDepth() || !commands.containsKey(args[getDepth()]))
             if (commands.containsKey("help"))
                 return commands.get("help").execute(sender, cmd, label, args);
-            else
-            {
+            else {
                 help(sender);
                 return null;
             }
@@ -38,23 +39,20 @@ public abstract class SubCommandHandler extends SubCommand
             return commands.get(args[getDepth()]).execute(sender, cmd, label, args);
     }
     
-    protected int getDepth()
-    {
+    protected int getDepth() {
         return depth;
     }
     
     @Override
-    public List<String> onTabComplete(CommandSender sender, String[] args)
-    {
-        switch (args.length - depth)
-        {
+    public List<String> onTabComplete(CommandSender sender, String[] args) {
+        switch (args.length - depth) {
             case 0:
                 return Collections.emptyList();
             case 1:
                 return commands.keySet().stream()
-                    .filter(a -> a.startsWith(args[args.length - 1]))
-                    .filter(a -> sender.hasPermission(commands.get(a).getPermission()))
-                    .collect(Collectors.toList());
+                        .filter(a -> a.startsWith(args[args.length - 1]))
+                        .filter(a -> sender.hasPermission(commands.get(a).getPermission()))
+                        .collect(Collectors.toList());
             default:
                 if (!commands.containsKey(args[depth]))
                     return Collections.emptyList();
@@ -66,24 +64,35 @@ public abstract class SubCommandHandler extends SubCommand
     @Override
     public abstract void help(CommandSender sender);
     
-    public void registerSubCommand(String name, SubCommand command, String... alias)
-    {
+    public abstract void registerSubCommands();
+    
+    public void registerSubCommand(String name, SubCommand command, String... alias) {
         Validate.notNull(command, "SubCommand can't be null!");
         Validate.notEmpty(name, "SubCommandname can't be empty!");
         Validate.isTrue(!commands.containsKey(name), "Command " + name + " is already defined");
         for (String a : alias)
             Validate.isTrue(!commands.containsKey(a), "Command " + a + " is already defined");
         
-        if (command instanceof SubCommandHandler)
+        if (command instanceof SubCommandHandler) {
             Validate.isTrue(((SubCommandHandler) command).getDepth() == getDepth() + 1, "The depth of a SubCommandHandler must be the depth of the previous Handler + 1!");
+            helpLabelManagers.forEach(helpLabelManager -> {
+                helpLabelManager.addLabel(name);
+                ((SubCommandHandler) command).addHelpLabelManager(helpLabelManager);
+            });
+        } else {
+            helpLabelManagers.forEach(helpLabelManager -> command.addHelpLabel(helpLabelManager, " " + name));
+        }
         
         commands.put(name, command);
         for (String s : alias)
             commands.put(s, command);
     }
     
-    protected Map<String, SubCommand> getCommands()
-    {
+    protected Map<String, SubCommand> getCommands() {
         return commands;
+    }
+    
+    public void addHelpLabelManager(CommandHandler.HelpLabelManager manager) {
+        helpLabelManagers.add(manager);
     }
 }

--- a/src/main/java/de/craftlancer/core/items/CustomItemAddCommand.java
+++ b/src/main/java/de/craftlancer/core/items/CustomItemAddCommand.java
@@ -1,12 +1,11 @@
 package de.craftlancer.core.items;
 
+import de.craftlancer.core.CLCore;
+import de.craftlancer.core.command.SubCommand;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-
-import de.craftlancer.core.CLCore;
-import de.craftlancer.core.command.SubCommand;
 
 public class CustomItemAddCommand extends SubCommand {
     
@@ -15,26 +14,27 @@ public class CustomItemAddCommand extends SubCommand {
     public CustomItemAddCommand(CLCore plugin, CustomItemRegistry registry) {
         super("clcore.itemregistry.add", plugin, false);
         this.registry = registry;
+        
     }
-
+    
     @Override
     protected String execute(CommandSender sender, Command cmd, String label, String[] args) {
-        if(!checkSender(sender))
+        if (!checkSender(sender))
             return "You can't run this command.";
         
         Player player = (Player) sender;
         ItemStack item = player.getInventory().getItemInMainHand();
         
-        if(item.getType().isAir()) 
+        if (item.getType().isAir())
             return "You must hold an item.";
-        if(args.length < 2)
+        if (args.length < 2)
             return "You must specify a key.";
         
         String key = args[1];
-        if(!key.matches("[a-zA-Z0-9_]+"))
+        if (!key.matches("[a-zA-Z0-9_]+"))
             return "Key must match [a-zA-Z0-9_]+";
-
-        if(registry.addItem(key, item) == null)
+        
+        if (registry.addItem(key, item) == null)
             return "Item successfully added.";
         else
             return "Item successfully replaced.";

--- a/src/main/java/de/craftlancer/core/items/CustomItemAddCommand.java
+++ b/src/main/java/de/craftlancer/core/items/CustomItemAddCommand.java
@@ -18,6 +18,16 @@ public class CustomItemAddCommand extends SubCommand {
     }
     
     @Override
+    public String[] getArgs() {
+        return new String[0];
+    }
+    
+    @Override
+    public String getDescription() {
+        return null;
+    }
+    
+    @Override
     protected String execute(CommandSender sender, Command cmd, String label, String[] args) {
         if (!checkSender(sender))
             return "You can't run this command.";

--- a/src/main/java/de/craftlancer/core/items/CustomItemCommandHandler.java
+++ b/src/main/java/de/craftlancer/core/items/CustomItemCommandHandler.java
@@ -4,10 +4,19 @@ import de.craftlancer.core.CLCore;
 import de.craftlancer.core.command.CommandHandler;
 
 public class CustomItemCommandHandler extends CommandHandler {
-
-    public CustomItemCommandHandler(CLCore plugin, CustomItemRegistry registry) {
-        super(plugin);
+    
+    private CLCore plugin;
+    private CustomItemRegistry registry;
+    
+    public CustomItemCommandHandler(CLCore plugin, String name, CustomItemRegistry registry) {
+        super(plugin, name);
         
+        this.plugin = plugin;
+        this.registry = registry;
+    }
+    
+    @Override
+    public void registerSubCommands() {
         registerSubCommand("add", new CustomItemAddCommand(plugin, registry));
         registerSubCommand("remove", new CustomItemRemoveCommand(plugin, registry));
         registerSubCommand("list", new CustomItemListCommand(plugin, registry));

--- a/src/main/java/de/craftlancer/core/items/CustomItemCommandHandler.java
+++ b/src/main/java/de/craftlancer/core/items/CustomItemCommandHandler.java
@@ -5,22 +5,12 @@ import de.craftlancer.core.command.CommandHandler;
 
 public class CustomItemCommandHandler extends CommandHandler {
     
-    private CLCore plugin;
-    private CustomItemRegistry registry;
-    
     public CustomItemCommandHandler(CLCore plugin, String name, CustomItemRegistry registry) {
-        super(plugin, name);
+        super(plugin);
         
-        this.plugin = plugin;
-        this.registry = registry;
-    }
-    
-    @Override
-    public void registerSubCommands() {
         registerSubCommand("add", new CustomItemAddCommand(plugin, registry));
         registerSubCommand("remove", new CustomItemRemoveCommand(plugin, registry));
         registerSubCommand("list", new CustomItemListCommand(plugin, registry));
         registerSubCommand("give", new CustomItemGiveCommand(plugin, registry));
     }
-    
 }

--- a/src/main/java/de/craftlancer/core/items/CustomItemGiveCommand.java
+++ b/src/main/java/de/craftlancer/core/items/CustomItemGiveCommand.java
@@ -21,8 +21,16 @@ public class CustomItemGiveCommand extends SubCommand {
         super("clcore.itemregistry.give", plugin, true);
         this.registry = registry;
         
-        setArguments("[player]", "[itemName]");
-        setDescription("Give a player a custom item registry item");
+    }
+    
+    @Override
+    public String[] getArgs() {
+        return new String[]{"[player]", "[itemName]"};
+    }
+    
+    @Override
+    public String getDescription() {
+        return "Give a player a custom item registry item";
     }
     
     @Override

--- a/src/main/java/de/craftlancer/core/items/CustomItemGiveCommand.java
+++ b/src/main/java/de/craftlancer/core/items/CustomItemGiveCommand.java
@@ -1,42 +1,44 @@
 package de.craftlancer.core.items;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
+import de.craftlancer.core.CLCore;
+import de.craftlancer.core.Utils;
+import de.craftlancer.core.command.SubCommand;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import de.craftlancer.core.CLCore;
-import de.craftlancer.core.Utils;
-import de.craftlancer.core.command.SubCommand;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class CustomItemGiveCommand extends SubCommand {
-
+    
     private CustomItemRegistry registry;
     
     public CustomItemGiveCommand(CLCore plugin, CustomItemRegistry registry) {
         super("clcore.itemregistry.give", plugin, true);
         this.registry = registry;
+        
+        setArguments("[player]", "[itemName]");
+        setDescription("Give a player a custom item registry item");
     }
     
     @Override
     protected String execute(CommandSender sender, Command cmd, String label, String[] args) {
-        if(!checkSender(sender))
+        if (!checkSender(sender))
             return "You can't run this command.";
         
-        if(args.length < 3)
+        if (args.length < 3)
             return "You must specify a player and an item name.";
         
         Player player = Bukkit.getPlayer(args[1]);
         Optional<ItemStack> item = registry.getItem(args[2]);
         
-        if(player == null)
+        if (player == null)
             return "Player not found.";
-        if(!item.isPresent())
+        if (!item.isPresent())
             return "Item not found.";
         
         player.getInventory().addItem(item.get());
@@ -51,9 +53,9 @@ public class CustomItemGiveCommand extends SubCommand {
     
     @Override
     protected List<String> onTabComplete(CommandSender sender, String[] args) {
-        if(args.length == 2)
+        if (args.length == 2)
             return Utils.getMatches(args[1], Bukkit.getOnlinePlayers().stream().map(Player::getName).collect(Collectors.toList()));
-        if(args.length == 3)
+        if (args.length == 3)
             return Utils.getMatches(args[2], registry.getKeys());
         
         return super.onTabComplete(sender, args);

--- a/src/main/java/de/craftlancer/core/items/CustomItemListCommand.java
+++ b/src/main/java/de/craftlancer/core/items/CustomItemListCommand.java
@@ -18,9 +18,16 @@ public class CustomItemListCommand extends SubCommand {
     public CustomItemListCommand(CLCore plugin, CustomItemRegistry registry) {
         super("clcore.itemregistry.list", plugin, true);
         this.registry = registry;
-        
-        setArguments("<page>", "[exampleArg]");
-        setDescription("List items");
+    }
+    
+    @Override
+    public String[] getArgs() {
+        return new String[]{"<page>", "[exampleArg]"};
+    }
+    
+    @Override
+    public String getDescription() {
+        return "List Items";
     }
     
     @Override

--- a/src/main/java/de/craftlancer/core/items/CustomItemListCommand.java
+++ b/src/main/java/de/craftlancer/core/items/CustomItemListCommand.java
@@ -1,8 +1,5 @@
 package de.craftlancer.core.items;
 
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-
 import de.craftlancer.core.CLCore;
 import de.craftlancer.core.Utils;
 import de.craftlancer.core.command.SubCommand;
@@ -10,25 +7,30 @@ import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
 
 public class CustomItemListCommand extends SubCommand {
     private static final long PAGE_ENTRY_COUNT = 10;
-
+    
     private CustomItemRegistry registry;
     
     public CustomItemListCommand(CLCore plugin, CustomItemRegistry registry) {
         super("clcore.itemregistry.list", plugin, true);
         this.registry = registry;
+        
+        setArguments("<page>", "[exampleArg]");
+        setDescription("List items");
     }
     
     @Override
     protected String execute(CommandSender sender, Command cmd, String label, String[] args) {
-        if(!checkSender(sender))
+        if (!checkSender(sender))
             return "You can't run this command.";
         
         int page = (args.length == 2 ? Integer.parseInt(args[1]) : 1) - 1;
         
-        if(page < 0)
+        if (page < 0)
             return "Page can't be negative!";
         
         sender.sendMessage("Page " + (page + 1));

--- a/src/main/java/de/craftlancer/core/items/CustomItemRegistry.java
+++ b/src/main/java/de/craftlancer/core/items/CustomItemRegistry.java
@@ -1,5 +1,14 @@
 package de.craftlancer.core.items;
 
+import de.craftlancer.core.CLCore;
+import de.craftlancer.core.LambdaRunnable;
+import org.apache.commons.lang.Validate;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
@@ -8,17 +17,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import org.apache.commons.lang.Validate;
-import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
-
-import de.craftlancer.core.CLCore;
-import de.craftlancer.core.LambdaRunnable;
 
 /**
  * Register custom items under a unique name to be used by other plugins.
@@ -36,18 +34,17 @@ public class CustomItemRegistry {
         YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
         config.getValues(false).forEach((a, b) -> items.put(a, (ItemStack) b));
         
-        plugin.getCommand("registerItem").setExecutor(new CustomItemCommandHandler(plugin, this));
+        plugin.getCommand("registerItem").setExecutor(new CustomItemCommandHandler(plugin, "registerItem", this));
     }
     
     public void save() {
         YamlConfiguration config = new YamlConfiguration();
         items.forEach(config::set);
-
+        
         BukkitRunnable saveTask = new LambdaRunnable(() -> {
             try {
                 config.save(file);
-            }
-            catch (IOException e) {
+            } catch (IOException e) {
                 plugin.getLogger().log(Level.SEVERE, "Error while saving ItemRegistry: ", e);
             }
         });
@@ -59,10 +56,10 @@ public class CustomItemRegistry {
     }
     
     /**
-     * Adds an {@link ItemStack} under the given key to the registry. 
+     * Adds an {@link ItemStack} under the given key to the registry.
      * If the key has been in use previously the old value will be overwritten.
-     * 
-     * @param key the key to be used
+     *
+     * @param key  the key to be used
      * @param item the item to be associated with the key
      * @return the item previously associated with that key or null
      */
@@ -75,7 +72,7 @@ public class CustomItemRegistry {
     
     /**
      * Removes a key->item association from the registry.
-     * 
+     *
      * @param key the key to remove
      * @return true when an association has been successfully removed, false otherwise
      */
@@ -85,7 +82,7 @@ public class CustomItemRegistry {
     
     /**
      * Gets the item associated with the given key, or null if non is found.
-     * 
+     *
      * @param key the key to look for
      * @return the item associated with the given key, or null if non is found
      */
@@ -96,7 +93,7 @@ public class CustomItemRegistry {
     
     /**
      * Gets whether an item is associated with the given key.
-     * 
+     *
      * @param key the key to look for
      * @return true when an item is associated with the key, false otherwise
      */
@@ -106,14 +103,14 @@ public class CustomItemRegistry {
     
     /**
      * Gets an immutable view of the key->ItemStack map.
-     * 
+     *
      * @return an immutable view of the key->ItemStack map
      */
     @Nonnull
     public Map<String, ItemStack> getItems() {
         return Collections.unmodifiableMap(items);
     }
-
+    
     public Collection<String> getKeys() {
         return Collections.unmodifiableSet(items.keySet());
     }

--- a/src/main/java/de/craftlancer/core/items/CustomItemRemoveCommand.java
+++ b/src/main/java/de/craftlancer/core/items/CustomItemRemoveCommand.java
@@ -1,13 +1,12 @@
 package de.craftlancer.core.items;
 
-import java.util.List;
-
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-
 import de.craftlancer.core.CLCore;
 import de.craftlancer.core.Utils;
 import de.craftlancer.core.command.SubCommand;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.util.List;
 
 public class CustomItemRemoveCommand extends SubCommand {
     
@@ -17,22 +16,32 @@ public class CustomItemRemoveCommand extends SubCommand {
         super("clcore.itemregistry.remove", plugin, true);
         this.registry = registry;
     }
-
+    
+    @Override
+    public String[] getArgs() {
+        return new String[0];
+    }
+    
+    @Override
+    public String getDescription() {
+        return null;
+    }
+    
     @Override
     protected String execute(CommandSender sender, Command cmd, String label, String[] args) {
-        if(!checkSender(sender))
+        if (!checkSender(sender))
             return "You can't run this command.";
         
-        if(args.length < 2)
+        if (args.length < 2)
             return "You must specify a key.";
         
         String key = args[1];
-        if(!key.matches("[a-zA-Z0-9_]+"))
+        if (!key.matches("[a-zA-Z0-9_]+"))
             return "Key must match [a-zA-Z0-9_]+";
-        if(!registry.hasItem(key))
+        if (!registry.hasItem(key))
             return "This key is not in use.";
-
-        if(registry.removeItem(key))
+        
+        if (registry.removeItem(key))
             return "Item successfully removed.";
         else
             return "Item couldn't be removed.";
@@ -46,7 +55,7 @@ public class CustomItemRemoveCommand extends SubCommand {
     
     @Override
     protected List<String> onTabComplete(CommandSender sender, String[] args) {
-        if(args.length == 2)
+        if (args.length == 2)
             return Utils.getMatches(args[1], registry.getKeys());
         
         


### PR DESCRIPTION
- HelpLabelManager - one instance per CommandHandler, will be passed through each SubCommandHandler to the SubCommand. From there, the subcommand adds a helpLabel (more info on next bullet point) to the HelpLabelManager. When a player uses the CommandHandlers and has first argument of "help", or no argument at all, the help component will be sent. 
- HelpLabel - one instance per SubCommand, created when a subcommand is registered. Can contain a label, description, permission, and optional/required arguments.
- Only constructor changes are to CommandHandler, to insert the commandhandler's label.
- Must now register commands only in the abstract `registerSubCommands` in both CommandHandler and SubCommandHandler